### PR TITLE
Use 01-index by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and packages already exist in the [community](https://www.archlinux.org/packages
 
 * Pacman database (`community.db`), ~~i.e., archlinux system.~~ the db file can be specified manually for now. 
 
-* Hackage database tarball (`00-index.tar`), usually provided by `cabal-install`.
+* Hackage database tarball (`01-index.tar`), usually provided by `cabal-install`.
 
 ## Installation
 
@@ -212,7 +212,7 @@ Usage: arch-hs [-h|--hackage PATH] [-c|--community PATH] [-o|--output PATH]
 
 Available options:
   -h,--hackage PATH        Path to
-                           00-index.tar (default: "~/.cabal/packages/YOUR_HACKAGE_MIRROR/00-index.tar")
+                           01-index.tar (default: "~/.cabal/packages/YOUR_HACKAGE_MIRROR/01-index.tar")
   -c,--community PATH      Path to
                            community.db (default: "/var/lib/pacman/sync/community.db")
   -o,--output PATH         Output path to generated PKGBUILD files (empty means

--- a/app/Args.hs
+++ b/app/Args.hs
@@ -34,9 +34,9 @@ cmdOptions =
       ( long "hackage"
           <> metavar "PATH"
           <> short 'h'
-          <> help "Path to 00-index.tar"
+          <> help "Path to 01-index.tar"
           <> showDefault
-          <> value "~/.cabal/packages/YOUR_HACKAGE_MIRROR/00-index.tar"
+          <> value "~/.cabal/packages/YOUR_HACKAGE_MIRROR/01-index.tar"
       )
       <*> strOption
         ( long "community"

--- a/diff/Diff.hs
+++ b/diff/Diff.hs
@@ -41,9 +41,9 @@ cmdOptions =
       ( long "hackage"
           <> metavar "PATH"
           <> short 'h'
-          <> help "Path to 00-index.tar"
+          <> help "Path to 01-index.tar"
           <> showDefault
-          <> value "~/.cabal/packages/YOUR_HACKAGE_MIRROR/00-index.tar"
+          <> value "~/.cabal/packages/YOUR_HACKAGE_MIRROR/01-index.tar"
       )
     <*> argument optPackageNameReader (metavar "TARGET")
     <*> argument optVersionReader (metavar "VERSION_A")

--- a/src/Hackage.hs
+++ b/src/Hackage.hs
@@ -33,10 +33,10 @@ lookupHackagePath :: IO FilePath
 lookupHackagePath = do
   home <- (\d -> d </> ".cabal" </> "packages") <$> getHomeDirectory
   subs <- fmap (home </>) <$> listDirectory home
-  target <- findFile subs "00-index.tar"
+  target <- findFile subs "01-index.tar"
   case target of
     Just x -> return x
-    Nothing -> fail $ "Unable to find hackage index [00-index.tar] from " ++ show subs
+    Nothing -> fail $ "Unable to find hackage index [01-index.tar] from " ++ show subs
 
 loadHackageDB :: FilePath -> IO HackageDB
 loadHackageDB = readTarball Nothing


### PR DESCRIPTION
According to https://www.well-typed.com/blog/2015/08/hackage-security-beta/
01-index.tar should be used instead of the old 01-index.tar.