### PR TITLE
Add URL in arch-hs-diff output

### DIFF
--- a/diff/Diff.hs
+++ b/diff/Diff.hs
@@ -173,7 +173,7 @@ ver :: PackageDescription -> PackageDescription -> String
 ver = diffTerm "Version: " (prettyShow . getPkgVersion)
 
 url :: PackageDescription -> PackageDescription -> String
-url = diffTerm "URL: " $ fromShortText . homepage
+url = diffTerm "URL: " getUrl
 
 dep :: String -> [String] -> [String] -> String
 dep s a b =

--- a/diff/Diff.hs
+++ b/diff/Diff.hs
@@ -134,6 +134,7 @@ diffCabal name a b = do
       [ C.formatWith [C.magenta] "Package: " <> unPackageName name,
         ver pa pb,
         desc pa pb,
+        url pa pb,
         dep "Depends: \n" ba bb,
         dep "MakeDepends: \n" ma mb
       ]
@@ -170,6 +171,9 @@ desc = diffTerm "Synopsis: " $ fromShortText . synopsis
 
 ver :: PackageDescription -> PackageDescription -> String
 ver = diffTerm "Version: " (prettyShow . getPkgVersion)
+
+url :: PackageDescription -> PackageDescription -> String
+url = diffTerm "URL: " $ fromShortText . homepage
 
 dep :: String -> [String] -> [String] -> String
 dep s a b =


### PR DESCRIPTION
(Actually it should reuse the logic in Core.hs:

```
  _url <- case fromShortText $ homepage cabal of
    "" -> fromJust . repoLocation <=< head' $ sourceRepos cabal
    x -> return x
```

But it's beyond my very limited haskell skill to really do that...