### PR TITLE
Fix compatibility with Cabal 3.4

### DIFF
--- a/app/Json.hs
+++ b/app/Json.hs
@@ -31,7 +31,7 @@ packageName (unPackageName -> name) = String $ T.pack name
 archLinuxName :: ArchLinuxName -> Value
 archLinuxName (ArchLinuxName name) = String $ T.pack name
 
-flag :: PackageFlag -> Value
+flag :: PkgFlag -> Value
 flag f =
   object
     [ "name" .= unFlagName (flagName f),
@@ -99,7 +99,7 @@ instance ToJSON SysDepsS where
 
 data FlagsS = FlagsS
   { fPkg :: PackageName,
-    fFlag :: [PackageFlag]
+    fFlag :: [PkgFlag]
   }
 
 instance ToJSON FlagsS where
@@ -137,5 +137,5 @@ fromSolvedPackage :: SolvedPackage -> SolvedPackageS
 fromSolvedPackage ProvidedPackage {..} = SolvedPackageS _pkgName [] (Just _pkgProvider)
 fromSolvedPackage SolvedPackage {..} = SolvedPackageS _pkgName (fromSolvedDependency <$> _pkgDeps) Nothing
 
-fromFlag :: (PackageName, [PackageFlag]) -> FlagsS
+fromFlag :: (PackageName, [PkgFlag]) -> FlagsS
 fromFlag (fPkg, fFlag) = FlagsS {..}

--- a/app/Json.hs
+++ b/app/Json.hs
@@ -31,7 +31,7 @@ packageName (unPackageName -> name) = String $ T.pack name
 archLinuxName :: ArchLinuxName -> Value
 archLinuxName (ArchLinuxName name) = String $ T.pack name
 
-flag :: Flag -> Value
+flag :: PackageFlag -> Value
 flag f =
   object
     [ "name" .= unFlagName (flagName f),
@@ -99,7 +99,7 @@ instance ToJSON SysDepsS where
 
 data FlagsS = FlagsS
   { fPkg :: PackageName,
-    fFlag :: [Flag]
+    fFlag :: [PackageFlag]
   }
 
 instance ToJSON FlagsS where
@@ -137,5 +137,5 @@ fromSolvedPackage :: SolvedPackage -> SolvedPackageS
 fromSolvedPackage ProvidedPackage {..} = SolvedPackageS _pkgName [] (Just _pkgProvider)
 fromSolvedPackage SolvedPackage {..} = SolvedPackageS _pkgName (fromSolvedDependency <$> _pkgDeps) Nothing
 
-fromFlag :: (PackageName, [Flag]) -> FlagsS
+fromFlag :: (PackageName, [PackageFlag]) -> FlagsS
 fromFlag (fPkg, fFlag) = FlagsS {..}

--- a/arch-hs.cabal
+++ b/arch-hs.cabal
@@ -98,6 +98,7 @@ library
   autogen-modules: Paths_arch_hs
   exposed-modules:
     Distribution.ArchHs.Aur
+    Distribution.ArchHs.Compat
     Distribution.ArchHs.CommunityDB
     Distribution.ArchHs.Core
     Distribution.ArchHs.Exception

--- a/diff/Diff.hs
+++ b/diff/Diff.hs
@@ -228,7 +228,7 @@ dep s va vb =
     joinToString xs = indent 2 $ vsep xs
     joinVersionWithName (n, range) = unPackageName n <> "  " <> prettyShow range
 
-flags :: PackageName -> [PackageFlag] -> [PackageFlag] -> Doc AnsiStyle
+flags :: PackageName -> [PkgFlag] -> [PkgFlag] -> Doc AnsiStyle
 flags name a b =
   annMagneta "Flags" <> colon <> line
     <> if noDiff diff

--- a/diff/Diff.hs
+++ b/diff/Diff.hs
@@ -228,7 +228,7 @@ dep s va vb =
     joinToString xs = indent 2 $ vsep xs
     joinVersionWithName (n, range) = unPackageName n <> "  " <> prettyShow range
 
-flags :: PackageName -> [Flag] -> [Flag] -> Doc AnsiStyle
+flags :: PackageName -> [PackageFlag] -> [PackageFlag] -> Doc AnsiStyle
 flags name a b =
   annMagneta "Flags" <> colon <> line
     <> if noDiff diff

--- a/src/Distribution/ArchHs/Compat.hs
+++ b/src/Distribution/ArchHs/Compat.hs
@@ -1,12 +1,22 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
 
-module Distribution.ArchHs.Compat (
-    PackageFlag
-) where
+module Distribution.ArchHs.Compat
+  ( pattern PkgFlag,
+    PkgFlag,
+  )
+where
+
+import Distribution.Types.ConfVar
+import Distribution.Types.Flag
+
+pattern PkgFlag :: FlagName -> ConfVar
+{-# COMPLETE PkgFlag #-}
 
 #if MIN_VERSION_Cabal(3,4,0)
-import Distribution.Types.Flag (PackageFlag)
+type PkgFlag = PackageFlag
+pattern PkgFlag x = PackageFlag x
 #else
-import Distribution.Types.Flag (Flag)
-type PackageFlag = Flag
+type PkgFlag = Flag
+pattern PkgFlag x = Flag x
 #endif

--- a/src/Distribution/ArchHs/Compat.hs
+++ b/src/Distribution/ArchHs/Compat.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE CPP #-}
+
+module Distribution.ArchHs.Compat (
+    PackageFlag
+) where
+
+#if MIN_VERSION_Cabal(3,4,0)
+import Distribution.Types.Flag (PackageFlag)
+#else
+import Distribution.Types.Flag (Flag)
+type PackageFlag = Flag
+#endif

--- a/src/Distribution/ArchHs/Core.hs
+++ b/src/Distribution/ArchHs/Core.hs
@@ -36,7 +36,7 @@ import Distribution.ArchHs.PkgBuild
 import Distribution.ArchHs.Types
 import Distribution.ArchHs.Utils
 import Distribution.Compiler (CompilerFlavor (..))
-import Distribution.PackageDescription
+import Distribution.PackageDescription hiding (pkgName)
 import Distribution.SPDX
 import Distribution.System (Arch (X86_64), OS (Linux))
 import qualified Distribution.Types.BuildInfo.Lens as L
@@ -51,7 +51,7 @@ archEnv _ (Arch X86_64) = Right True
 archEnv _ (Arch _) = Right False
 archEnv _ (Impl GHC range) = Right $ withinRange (mkVersion [8, 10, 4]) range
 archEnv _ (Impl _ _) = Right False
-archEnv assignment f@(Flag f') = go f $ lookupFlagAssignment f' assignment
+archEnv assignment f@(PackageFlag f') = go f $ lookupFlagAssignment f' assignment
   where
     go _ (Just r) = Right r
     go x Nothing = Left x

--- a/src/Distribution/ArchHs/Core.hs
+++ b/src/Distribution/ArchHs/Core.hs
@@ -51,7 +51,7 @@ archEnv _ (Arch X86_64) = Right True
 archEnv _ (Arch _) = Right False
 archEnv _ (Impl GHC range) = Right $ withinRange (mkVersion [8, 10, 4]) range
 archEnv _ (Impl _ _) = Right False
-archEnv assignment f@(PackageFlag f') = go f $ lookupFlagAssignment f' assignment
+archEnv assignment f@(PkgFlag f') = go f $ lookupFlagAssignment f' assignment
   where
     go _ (Just r) = Right r
     go x Nothing = Left x

--- a/src/Distribution/ArchHs/Hackage.hs
+++ b/src/Distribution/ArchHs/Hackage.hs
@@ -93,7 +93,7 @@ getCabal name version = do
     Nothing -> throw $ PkgNotFound name
 
 -- | Get flags of a package.
-getPackageFlag :: Members [HackageEnv, WithMyErr] r => PackageName -> Sem r [Flag]
+getPackageFlag :: Members [HackageEnv, WithMyErr] r => PackageName -> Sem r [PackageFlag]
 getPackageFlag name = do
   cabal <- getLatestCabal name
   return $ cabal & genPackageFlags

--- a/src/Distribution/ArchHs/Hackage.hs
+++ b/src/Distribution/ArchHs/Hackage.hs
@@ -93,7 +93,7 @@ getCabal name version = do
     Nothing -> throw $ PkgNotFound name
 
 -- | Get flags of a package.
-getPackageFlag :: Members [HackageEnv, WithMyErr] r => PackageName -> Sem r [PackageFlag]
+getPackageFlag :: Members [HackageEnv, WithMyErr] r => PackageName -> Sem r [PkgFlag]
 getPackageFlag name = do
   cabal <- getLatestCabal name
   return $ cabal & genPackageFlags

--- a/src/Distribution/ArchHs/Internal/Prelude.hs
+++ b/src/Distribution/ArchHs/Internal/Prelude.hs
@@ -31,6 +31,7 @@ module Distribution.ArchHs.Internal.Prelude
     module Polysemy.Reader,
     module Polysemy.State,
     module Polysemy.Trace,
+    module Distribution.ArchHs.Compat,
     module Distribution.Types.PackageDescription,
     module Distribution.Types.GenericPackageDescription,
     module Distribution.Types.Version,
@@ -60,6 +61,7 @@ import Data.Text.Encoding
   ( decodeUtf8,
     encodeUtf8,
   )
+import Distribution.ArchHs.Compat
 import Distribution.Parsec (simpleParsec)
 import Distribution.Pretty (prettyShow)
 import Distribution.Types.Flag

--- a/src/Distribution/ArchHs/PP.hs
+++ b/src/Distribution/ArchHs/PP.hs
@@ -97,10 +97,10 @@ prettyDeps =
     . fmap (\(i :: Int, n) -> pretty i <> dot <+> viaPretty n)
     . zip [1 ..]
 
-prettyFlags :: [(PackageName, [PackageFlag])] -> Doc AnsiStyle
+prettyFlags :: [(PackageName, [PkgFlag])] -> Doc AnsiStyle
 prettyFlags = vsep . fmap (\(name, flags) -> annMagneta (viaPretty name) <> line <> indent 2 (vsep (prettyFlag <$> flags)))
 
-prettyFlag :: PackageFlag -> Doc AnsiStyle
+prettyFlag :: PkgFlag -> Doc AnsiStyle
 prettyFlag f =
   "⚐" <+> annYellow name <> colon <> line
     <> indent

--- a/src/Distribution/ArchHs/PP.hs
+++ b/src/Distribution/ArchHs/PP.hs
@@ -97,10 +97,10 @@ prettyDeps =
     . fmap (\(i :: Int, n) -> pretty i <> dot <+> viaPretty n)
     . zip [1 ..]
 
-prettyFlags :: [(PackageName, [Flag])] -> Doc AnsiStyle
+prettyFlags :: [(PackageName, [PackageFlag])] -> Doc AnsiStyle
 prettyFlags = vsep . fmap (\(name, flags) -> annMagneta (viaPretty name) <> line <> indent 2 (vsep (prettyFlag <$> flags)))
 
-prettyFlag :: Flag -> Doc AnsiStyle
+prettyFlag :: PackageFlag -> Doc AnsiStyle
 prettyFlag f =
   "⚐" <+> annYellow name <> colon <> line
     <> indent


### PR DESCRIPTION
Flag was renamed to PackageFlag and CompilerFlag. We should be only
using PackageFlag here.