### PR TITLE
Don't ignore old-time

### DIFF
--- a/src/Distribution/ArchHs/Local.hs
+++ b/src/Distribution/ArchHs/Local.hs
@@ -24,7 +24,6 @@ ignoreList =
           "integer-simple",
           "bytestring-builder",
           "nats",
-          "old-time",
           "integer",
           "unsupported-ghc-version",
           "rts",


### PR DESCRIPTION
It's still a valid third-party dependency as of today.