### PR TITLE
Drop gtk3 rename from NAME_PRESET

### DIFF
--- a/data/NAME_PRESET.json
+++ b/data/NAME_PRESET.json
@@ -36,7 +36,6 @@
   "haskell-gi-base": "haskell-gi-base",
   "haskell-gi-overloading": "haskell-gi-overloading",
   "haskell-glob": "Glob",
-  "haskell-gtk": "gtk3",
   "haskell-graphscc": "GraphSCC",
   "haskell-hopenpgp": "hOpenPGP",
   "haskell-htf": "HTF",


### PR DESCRIPTION
It's renamed back to haskell-gtk3 already: https://github.com/archlinux/svntogit-community/commit/b39675412541381abaa0997354e2b4fc74d39473