### PR TITLE
Add haskell-src-exts-simple to NAME_PRESET

### DIFF
--- a/data/NAME_PRESET.json
+++ b/data/NAME_PRESET.json
@@ -77,6 +77,7 @@
   "haskell-smtlib": "smtLib",
   "haskell-src": "haskell-src",
   "haskell-src-exts": "haskell-src-exts",
+  "haskell-src-exts-simple": "haskell-src-exts-simple",
   "haskell-src-exts-util": "haskell-src-exts-util",
   "haskell-src-meta": "haskell-src-meta",
   "haskell-statevar": "StateVar",


### PR DESCRIPTION
It was missing from the last batch.