### PR TITLE
Use single quotes for string literals

### DIFF
--- a/src/Distribution/ArchHs/PkgBuild.hs
+++ b/src/Distribution/ArchHs/PkgBuild.hs
@@ -577,8 +577,8 @@ felixTemplate hkgname pkgname pkgver pkgdesc url license depends makedepends sha
   pkgname=$pkgname
   pkgver=$pkgver
   pkgrel=1
-  pkgdesc="$pkgdesc"
-  url="$url"
+  pkgdesc='${pkgdesc}'
+  url='${url}'
   license=("$license")
   arch=('x86_64')
   depends=('ghc-libs'$depends)


### PR DESCRIPTION
`pkgdesc` and `url` customarily use single quotes. This also avoids code substitution issues with arbitrary input.

Fixes #51