### PR TITLE
feat: Auto-generate uusi for necessary pkgs

### DIFF
--- a/src/Distribution/ArchHs/Core.hs
+++ b/src/Distribution/ArchHs/Core.hs
@@ -24,8 +24,13 @@ module Distribution.ArchHs.Core
 where
 
 import qualified Algebra.Graph.Labelled.AdjacencyMap as G
+import Conduit
+import Control.Monad (filterM, unless)
 import Data.Bifunctor (second)
+import qualified Data.ByteString as BS
+import qualified Data.Conduit.Tar as Tar
 import Data.Containers.ListUtils (nubOrd)
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.Map as Map
 import Data.List (sort)
 import Data.Maybe (fromMaybe)
@@ -37,6 +42,7 @@ import Distribution.ArchHs.Hackage
   ( getLatestCabal,
     getLatestSHA256,
     getPackageFlag,
+    lookupHackagePath,
   )
 import Distribution.ArchHs.Internal.Prelude
 import Distribution.ArchHs.Local (ignoreList)
@@ -48,13 +54,15 @@ import Distribution.ArchHs.PkgBuild
   )
 import Distribution.ArchHs.Types
 import Distribution.ArchHs.Utils
-import Distribution.Compiler (CompilerFlavor (..))
+import Distribution.Compiler (CompilerFlavor (..), AbiTag (..), buildCompilerId, unknownCompilerInfo)
 import Distribution.PackageDescription hiding (pkgName)
+import Distribution.PackageDescription.Configuration
+import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
 import Distribution.SPDX
-import Distribution.System (Arch (X86_64), OS (Linux))
+import Distribution.System (Arch (X86_64), OS (Linux), Platform (..))
 import qualified Distribution.Types.BuildInfo.Lens as L
 import Distribution.Types.CondTree (simplifyCondTree)
-import Distribution.Types.Dependency (Dependency)
+import Distribution.Types.ComponentRequestedSpec (ComponentRequestedSpec (..))
 import Distribution.Utils.ShortText (fromShortText)
 
 archEnv :: Version -> FlagAssignment -> ConfVar -> Either ConfVar Bool
@@ -286,11 +294,68 @@ updateDependencyRecord name range = modify' $ Map.insertWith (<>) name [range]
 
 -----------------------------------------------------------------------------
 
+inRange :: Members [ExtraEnv, WithMyErr] r => (PackageName, VersionRange) -> Sem r (Either (PackageName, VersionRange) (PackageName, VersionRange, Version, Bool))
+inRange (name, hRange) =
+  try @MyException (versionInExtra name)
+    >>= \case
+      Right rawVersion ->
+        case simpleParsec rawVersion of
+          Just version -> return . Right $ (name, hRange, version, withinRange version hRange)
+          Nothing -> throw $ VersionNoParse rawVersion
+      Left _ -> return . Left $ (name, hRange)
+
+isInRangeBool :: Members [ExtraEnv, WithMyErr] r => PackageName -> VersionRange -> Sem r Bool
+isInRangeBool name hRange = do
+  l <- inRange (name, hRange)
+  case l of
+    Right (_, _, _, i) -> return i
+    Left _ -> return False
+
+isNotInRangeBool :: Members [ExtraEnv, WithMyErr] r => PackageName -> VersionRange -> Sem r Bool
+isNotInRangeBool name hRange = do
+  l <- isInRangeBool name hRange
+  return (not l)
+
+getCabalsFromIndex :: Members [Embed IO, WithMyErr] r => FilePath -> PackageName -> [Version] -> Sem r (Map.Map Version GenericPackageDescription)
+getCabalsFromIndex hackagePath name versions = do
+  let pkg = unPackageName name
+      cabalPaths = Map.fromList [(pkg </> prettyShow version </> (pkg <> ".cabal"), version) | version <- nub versions]
+  cabalFiles <- embed $ findCabalFilesInIndex hackagePath cabalPaths
+  Map.fromList <$> traverse (parseCabal cabalFiles) (nub versions)
+  where
+    parseCabal cabalFiles version =
+      case parseGenericPackageDescriptionMaybe =<< Map.lookup version cabalFiles of
+        Just cabal -> return (version, cabal)
+        Nothing -> throw $ VersionNotFound name version
+
+findCabalFilesInIndex :: FilePath -> Map.Map FilePath Version -> IO (Map.Map Version BS.ByteString)
+findCabalFilesInIndex hackagePath cabalPaths = do
+  foundRef <- newIORef Map.empty
+  Map.fromList
+    <$> runConduitRes
+      ( sourceFileBS hackagePath
+          .| Tar.untarChunks
+          .| Tar.withEntries (action foundRef)
+          .| takeC (Map.size cabalPaths)
+          .| sinkList
+      )
+  where
+    action foundRef header
+      | Tar.FTNormal <- Tar.headerFileType header,
+        Just version <- Map.lookup (Tar.headerFilePath header) cabalPaths = do
+        found <- liftIO $ readIORef foundRef
+        unless (Map.member version found) $ do
+          cabalFile <- mconcat <$> sinkList
+          liftIO $ modifyIORef' foundRef (Map.insert version ())
+          yield (version, cabalFile)
+      | otherwise = return ()
+
 -- | Generate 'PkgBuild' for a 'SolvedPackage'.
-cabalToPkgBuild :: Members [HackageEnv, FlagAssignmentsEnv, WithMyErr] r => SolvedPackage -> Bool -> [ArchLinuxName] -> Sem r PkgBuild
+cabalToPkgBuild :: Members [Embed IO, ExtraEnv, HackageEnv, FlagAssignmentsEnv, WithMyErr] r => SolvedPackage -> Bool -> [ArchLinuxName] -> Sem r PkgBuild
 cabalToPkgBuild pkg uusi sysDeps = do
   let name = pkg ^. pkgName
-  cabal <- packageDescription <$> getLatestCabal name
+  latestCabal <- getLatestCabal name
+  let cabal = packageDescription latestCabal
   pkgFlags <- getPackageFlag name
   assignment <- getFlagAssignment name <$> ask
   let showFlagForCmd (unFlagName -> fName, enabled) = "-f" <> (if enabled then "" else "-") <> fName
@@ -298,7 +363,8 @@ cabalToPkgBuild pkg uusi sysDeps = do
   _sha256sums <- (\case Just s -> "'" <> s <> "'"; Nothing -> "'SKIP'") <$> getLatestSHA256 name
   let _hkgName = pkg ^. pkgName & unPackageName
       _pkgName = unArchLinuxName . toArchLinuxName $ pkg ^. pkgName
-      _pkgVer = prettyShow $ getPkgVersion cabal
+      pkgVersion = getPkgVersion cabal
+      _pkgVer = prettyShow $ pkgVersion
       _pkgDesc = fromShortText $ synopsis cabal
       getL NONE = ""
       getL (License e) = getE e
@@ -339,11 +405,32 @@ cabalToPkgBuild pkg uusi sysDeps = do
               )
       depsToString k deps = (sort $ deps <&> (wrap . unArchLinuxName . toArchLinuxName . k)) & mconcat
       _depends = depsToString _depName depends <> depsToString id sysDeps
-      _makeDepends = (if uusi then " 'uusi'" else "") <> depsToString _depName makeDepends
       _url = getUrl cabal
       wrap s = " '" <> s <> "'"
       _licenseFile = licenseFile cabal
-      _enableUusi = uusi
+      pd = (finalizePD assignment (ComponentRequestedSpec True False) (\_ -> True) (Platform X86_64 Linux) (unknownCompilerInfo buildCompilerId NoAbiTag) [] latestCabal)
+      finalisedPackageDescription = (\case Right (x, _) -> x; Left _ -> error $ "Missing dependencies") pd
+      versionRanges = Map.fromList $ enabledBuildDepends finalisedPackageDescription (ComponentRequestedSpec True False) <&> (\dep -> (depPkgName dep, depVerRange dep))
+      -- If dep has been removed in revision, then it clearly isn't needed, so ignore the version bounds
+      revisedIsInRange dep = (\case Just version -> isInRangeBool dep version; Nothing -> return True) (Map.lookup dep versionRanges)
+
+  hackagePath <- embed $ lookupHackagePath
+  cabals <- getCabalsFromIndex hackagePath name [pkgVersion]
+  let lookupCabal cs version = (\case Just c -> return c; Nothing -> throw $ VersionNotFound name version) $ Map.lookup version cs
+  unrevisedCabalFile <- lookupCabal cabals pkgVersion
+  let unrevisedPd = (finalizePD assignment (ComponentRequestedSpec True False) (\_ -> True) (Platform X86_64 Linux) (unknownCompilerInfo buildCompilerId NoAbiTag) [] unrevisedCabalFile)
+      finalisedUnrevisedPackageDescription = (\case Right (x, _) -> x; Left _ -> error $ "Missing dependencies") unrevisedPd
+      unRevisedEnabledBuildDepends = enabledBuildDepends finalisedUnrevisedPackageDescription (ComponentRequestedSpec True False)
+      unrevisedVersionRanges = Map.fromList $ unRevisedEnabledBuildDepends <&> (\dep -> (depPkgName dep, depVerRange dep))
+      unrevisedIsNotInRange x = isNotInRangeBool x (fromMaybe (error $ "Internal error: Dependency '" <> prettyShow x <> "' is declared as depends or makedepends " <>
+                                                                       "while not being a dependency of an enabled component in the unrevised .cabal.")
+                                                              $ Map.lookup x unrevisedVersionRanges)
+  outOfBounds <- filterM unrevisedIsNotInRange $ sort (unRevisedEnabledBuildDepends <&> depPkgName)
+  revisedInBounds <- filterM revisedIsInRange $ outOfBounds
+  let _removeWithUusi = map prettyShow revisedInBounds
+      _enableUusi = uusi || (not (null _removeWithUusi))
+      _makeDepends = (if _enableUusi then " 'uusi'" else "") <> depsToString _depName makeDepends
+  -- _ <- error $ ((Map.assocs versionRanges) <&> (\x -> " " <> prettyShow (fst x) <> " " <> prettyShow (snd x)) & mconcat) <> "\nUnrevised version ranges: " <> ((Map.assocs unrevisedVersionRanges) <&> (\x -> " " <> prettyShow (fst x) <> " " <> prettyShow (snd x)) & mconcat) <> "\nTo remove with uusi: " <> (mconcat (map (\x -> x <> " ") (_removeWithUusi)))
   return PkgBuild {..}
 
 -----------------------------------------------------------------------------

--- a/src/Distribution/ArchHs/PkgBuild.hs
+++ b/src/Distribution/ArchHs/PkgBuild.hs
@@ -19,6 +19,7 @@ where
 
 import Data.Text (Text, pack, unpack)
 import Distribution.SPDX.LicenseId
+import Lens.Micro ((&), (<&>))
 import NeatInterpolation (text)
 import qualified Web.ArchLinux.Types as Arch
 
@@ -46,6 +47,8 @@ data PkgBuild = PkgBuild
     _licenseFile :: Maybe String,
     -- | Whether generate @prepare()@ bash function which calls @uusi@
     _enableUusi :: Bool,
+    -- | List of dependencies whose version ranges will be removed in the @prepare()@ bash function using @uusi@
+    _removeWithUusi :: [String],
     -- | Command-line flags
     _flags :: String
   }
@@ -533,7 +536,7 @@ applyTemplate PkgBuild {..} =
           Just n -> "\n" <> installLicense (pack n)
           _ -> "\n"
       )
-      (if _enableUusi then "\n" <> uusi <> "\n\n" else "\n")
+      (if _enableUusi then "\n" <> (prepare . pack $ "uusi" <> (_removeWithUusi <&> (\r -> " -u " <> r) & mconcat)) <> "\n\n" else "\n")
       ("\n" <> check <> "\n\n")
       ( pack $ case _flags of
           [] -> ""
@@ -558,11 +561,12 @@ installLicense licenseFile =
     rm -f "$$pkgdir"/usr/share/doc/$$pkgname/$licenseFile
 |]
 
-uusi :: Text
-uusi =
+prepare :: Text -> Text
+prepare uusi =
   [text|
   prepare() {
-    uusi $$_hkgname-$$pkgver/$$_hkgname.cabal
+    cd $$_hkgname-$$pkgver
+    $uusi
   }
 |]
 


### PR DESCRIPTION
The Hackage index contains the revised bounds for updated dependencies. Arch Linux, however, operates on the unrevised files and instead uses `uusi` to ignore the version bounds.

The previous implementation of just ignoring all version bounds has been improved to only use it for the packages that actually need it and for which it has been confirmed that they work. The dependencies are sorted alphabetically with uppercase first, then lowercase.

Much of the implementation to retrieve the unrevised package version stems from arch-hs-diff which uses them.

<details><summary>Tested with attoparsec 0.14.4</summary>
<p>

```
# This file was generated by https://github.com/berberman/arch-hs, please check it manually.
# Maintainer: Your Name <youremail@domain.com>

_hkgname=attoparsec
pkgname=haskell-attoparsec
pkgver=0.14.4
pkgrel=1
pkgdesc="Fast combinator parsing for bytestrings and text"
url="https://github.com/haskell/attoparsec"
license=("BSD-3-Clause")
arch=('x86_64')
depends=('ghc-libs' 'haskell-scientific')
makedepends=('ghc' 'uusi' 'haskell-quickcheck' 'haskell-quickcheck-unicode' 'haskell-tasty' 'haskell-tasty-quickcheck' 'haskell-vector')
source=("https://hackage.haskell.org/packages/archive/$_hkgname/$pkgver/$_hkgname-$pkgver.tar.gz")
sha256sums=('3f337fe58624565de12426f607c23e60c7b09c86b4e3adfc827ca188c9979e6c')

prepare() {
  cd $_hkgname-$pkgver
  uusi -u QuickCheck -u ghc-prim
}

build() {
  cd $_hkgname-$pkgver

  runhaskell Setup configure -O --enable-shared --enable-debug-info --enable-executable-dynamic --disable-library-vanilla \
    --prefix=/usr --docdir=/usr/share/doc/$pkgname --datasubdir=$pkgname --enable-tests \
    --dynlibdir=/usr/lib --libsubdir=\$compiler/site-local/\$pkgid \
    --ghc-option=-optl-Wl\,-z\,relro\,-z\,now \
    --ghc-option='-pie' \
    -f-developer

  runhaskell Setup build
  runhaskell Setup register --gen-script
  runhaskell Setup unregister --gen-script
  sed -i -r -e "s|ghc-pkg.*update[^ ]* |&'--force' |" register.sh
  sed -i -r -e "s|ghc-pkg.*unregister[^ ]* |&'--force' |" unregister.sh
}

check() {
  cd $_hkgname-$pkgver
  runhaskell Setup test
}

package() {
  cd $_hkgname-$pkgver

  install -D -m744 register.sh "$pkgdir"/usr/share/haskell/register/$pkgname.sh
  install -D -m744 unregister.sh "$pkgdir"/usr/share/haskell/unregister/$pkgname.sh
  runhaskell Setup copy --destdir="$pkgdir"
  install -D -m644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname/
  rm -f "$pkgdir"/usr/share/doc/$pkgname/LICENSE
}
```

</p>
</details> 

Fixes #90

----
The implementation is in need of cleanup before it can be merged, so it's marked as draft for now.

Main points for improvement:
- [ ] Move cabal file retrieval into Hackage.hs
- [ ] Support different filepath for Hackage Index (currently only considers the default path)
- [ ] Compute version ranges in separate function instead of inline

If you want to try it out and add some thoughts, feel free to reply in the comments.